### PR TITLE
Refine auth session handling

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -269,7 +269,7 @@ router.delete('/del/:id', authenticateToken, async (req, res) => {
   }
 });
 
-// API สำหรับ Refresh Token
+// API endpoint for refreshing tokens
 router.post('/refresh', async (req, res) => {
   const { refreshToken } = req.body;
 

--- a/frontend/src/app/Supportpal/page.jsx
+++ b/frontend/src/app/Supportpal/page.jsx
@@ -136,10 +136,10 @@ const cloneSite = (site) => {
   return cloneSites([site])[0];
 };
 
-// NOTE: ปรับค่า MONTHLY_RESET_* เพื่อกำหนดเวลาการรีเซ็ตสถานะการยืนยันสำหรับ SupportPal
-const MONTHLY_RESET_DAY = 1; // วันที่ต้องการรีเซ็ต (1 = วันที่ 1 ของเดือน)
-const MONTHLY_RESET_HOUR = 0; // ชั่วโมงที่ต้องการให้รีเซ็ต (24 ชั่วโมง)
-const MONTHLY_RESET_MINUTE = 0; // นาทีที่ต้องการให้รีเซ็ต
+// NOTE: Adjust MONTHLY_RESET_* to control when SupportPal confirmation states are reset
+const MONTHLY_RESET_DAY = 1; // Day to perform the reset (1 = first day of the month)
+const MONTHLY_RESET_HOUR = 0; // Hour to perform the reset (24-hour clock)
+const MONTHLY_RESET_MINUTE = 0; // Minute to perform the reset
 
 const SpDashboard = () => {
   const [sites, setSites] = useState([]);

--- a/frontend/src/app/WordPress/page.jsx
+++ b/frontend/src/app/WordPress/page.jsx
@@ -143,10 +143,10 @@ const cloneSite = (site) => {
   return cloneSites([site])[0];
 };
 
-// NOTE: ปรับค่า WEEKLY_RESET_* เพื่อเปลี่ยนเวลาการรีเซ็ตสถานะเว็บไซต์ที่ยืนยันแล้ว
-const WEEKLY_RESET_DAY = 1; // วันจันทร์ (0 = อาทิตย์, 1 = จันทร์, ...)
-const WEEKLY_RESET_HOUR = 0; // ชั่วโมงที่ต้องการให้รีเซ็ต (24 ชั่วโมง)
-const WEEKLY_RESET_MINUTE = 0; // นาทีที่ต้องการให้รีเซ็ต
+// NOTE: Adjust WEEKLY_RESET_* to change when confirmed WordPress sites are reset
+const WEEKLY_RESET_DAY = 1; // Monday (0 = Sunday, 1 = Monday, ...)
+const WEEKLY_RESET_HOUR = 0; // Hour to perform the reset (24-hour clock)
+const WEEKLY_RESET_MINUTE = 0; // Minute to perform the reset
 
 const WpDashboard = () => {
   const [sites, setSites] = useState([]);
@@ -389,7 +389,7 @@ const WpDashboard = () => {
 
     try {
       for (const site of confirmedSites) {
-        // ใช้ skipReload เพื่อให้โหลดข้อมูลใหม่เพียงครั้งเดียวหลังอัปเดตทั้งหมด
+        // Use skipReload so data is fetched once after all updates complete
         await persistSite(
           site.id,
           { isConfirmed: false },
@@ -571,7 +571,7 @@ const WpDashboard = () => {
     }));
   };
 
-  // ปรับปรุงการ validation ในฟังก์ชัน saveChanges
+  // Additional validation logic for the saveChanges function
   const saveChanges = async () => {
     if (!formData.name || !formData.url) {
       setFormStatus({ type: 'error', message: 'Please enter the website name and URL' });

--- a/frontend/src/app/components/AuthGuard.jsx
+++ b/frontend/src/app/components/AuthGuard.jsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
+
+import AuthContext from '../lib/auth-context';
 
 const ADMIN_ONLY_PATH_PREFIXES = ['/wordpress', '/supportpal', '/admin'];
 const EMPTY_EXCLUDED_PATHS = Object.freeze([]);
@@ -31,6 +33,37 @@ const normaliseExcludedPaths = (paths) => {
   return Array.from(deduped);
 };
 
+const isAdminUser = (user) =>
+  typeof user?.role === 'string' && normaliseString(user.role) === 'admin';
+
+const readStoredJson = (key) => {
+  try {
+    const rawValue = localStorage.getItem(key);
+
+    return rawValue ? JSON.parse(rawValue) : null;
+  } catch (error) {
+    console.error(`Unable to parse stored value for "${key}"`, error);
+    localStorage.removeItem(key);
+    return null;
+  }
+};
+
+const areSessionsEqual = (first, second) => {
+  if (first === second) {
+    return true;
+  }
+
+  if (!first || !second) {
+    return false;
+  }
+
+  return (
+    first.accessToken === second.accessToken &&
+    first.refreshToken === second.refreshToken &&
+    JSON.stringify(first.user) === JSON.stringify(second.user)
+  );
+};
+
 export default function AuthGuard({ children, excludedPaths }) {
   const router = useRouter();
   const pathname = usePathname();
@@ -38,13 +71,18 @@ export default function AuthGuard({ children, excludedPaths }) {
     checking: true,
     authorized: false,
   });
+  const [session, setSession] = useState({
+    accessToken: null,
+    refreshToken: null,
+    user: null,
+  });
 
   const resolvedExcludedPaths = useMemo(
     () => normaliseExcludedPaths(excludedPaths),
     [excludedPaths],
   );
 
-  const commitAuthState = (nextState) => {
+  const commitAuthState = useCallback((nextState) => {
     setAuthState((previous) => {
       if (
         previous.checking === nextState.checking &&
@@ -55,7 +93,60 @@ export default function AuthGuard({ children, excludedPaths }) {
 
       return nextState;
     });
-  };
+  }, []);
+
+  const clearStoredSession = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
+    localStorage.removeItem('user');
+    setSession((previous) => {
+      if (
+        previous.accessToken === null &&
+        previous.refreshToken === null &&
+        previous.user === null
+      ) {
+        return previous;
+      }
+
+      return {
+        accessToken: null,
+        refreshToken: null,
+        user: null,
+      };
+    });
+  }, []);
+
+  const setUser = useCallback((updater, { persist = false } = {}) => {
+    let nextUserValue = null;
+
+    setSession((previous) => {
+      nextUserValue =
+        typeof updater === 'function' ? updater(previous.user) : updater;
+
+      if (persist && typeof window !== 'undefined') {
+        if (nextUserValue) {
+          localStorage.setItem('user', JSON.stringify(nextUserValue));
+        } else {
+          localStorage.removeItem('user');
+        }
+      }
+
+      const resolvedUser = nextUserValue ?? null;
+
+      if (previous.user === resolvedUser) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        user: resolvedUser,
+      };
+    });
+  }, []);
 
   useEffect(() => {
     const normalisedPath = normaliseString(pathname);
@@ -66,43 +157,56 @@ export default function AuthGuard({ children, excludedPaths }) {
       return;
     }
 
+    if (typeof window === 'undefined') {
+      commitAuthState({ checking: false, authorized: false });
+      return;
+    }
+
     const accessToken = localStorage.getItem('accessToken');
+    const refreshToken = localStorage.getItem('refreshToken');
 
     if (!accessToken) {
+      clearStoredSession();
       commitAuthState({ checking: false, authorized: false });
       router.replace('/login');
       return;
     }
+
+    const storedUser = readStoredJson('user');
+
+    setSession((previous) => {
+      const nextSession = {
+        accessToken,
+        refreshToken,
+        user: storedUser,
+      };
+
+      if (areSessionsEqual(previous, nextSession)) {
+        return previous;
+      }
+
+      return nextSession;
+    });
 
     const requiresAdmin = ADMIN_ONLY_PATH_PREFIXES.some(
       (prefix) =>
         normalisedPath === prefix || normalisedPath.startsWith(`${prefix}/`),
     );
 
-    if (requiresAdmin) {
-      let storedUser = null;
-
-      try {
-        const rawUser = localStorage.getItem('user');
-        storedUser = rawUser ? JSON.parse(rawUser) : null;
-      } catch (error) {
-        console.error('Unable to parse stored user:', error);
-        localStorage.removeItem('user');
-      }
-
-      const isAdmin =
-        typeof storedUser?.role === 'string' &&
-        normaliseString(storedUser.role) === 'admin';
-
-      if (!isAdmin) {
-        commitAuthState({ checking: false, authorized: false });
-        router.replace('/');
-        return;
-      }
+    if (requiresAdmin && !isAdminUser(storedUser)) {
+      commitAuthState({ checking: false, authorized: false });
+      router.replace('/');
+      return;
     }
 
     commitAuthState({ checking: false, authorized: true });
-  }, [router, pathname, resolvedExcludedPaths]);
+  }, [
+    router,
+    pathname,
+    resolvedExcludedPaths,
+    clearStoredSession,
+    commitAuthState,
+  ]);
 
   if (authState.checking) {
     return <div>Loading...</div>;
@@ -112,5 +216,18 @@ export default function AuthGuard({ children, excludedPaths }) {
     return null;
   }
 
-  return <>{children}</>;
+  const contextValue = useMemo(
+    () => ({
+      accessToken: session.accessToken,
+      clearAuth: clearStoredSession,
+      refreshToken: session.refreshToken,
+      setUser,
+      user: session.user,
+    }),
+    [session, clearStoredSession, setUser],
+  );
+
+  return (
+    <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>
+  );
 }

--- a/frontend/src/app/components/AuthGuard.jsx
+++ b/frontend/src/app/components/AuthGuard.jsx
@@ -208,14 +208,6 @@ export default function AuthGuard({ children, excludedPaths }) {
     commitAuthState,
   ]);
 
-  if (authState.checking) {
-    return <div>Loading...</div>;
-  }
-
-  if (!authState.authorized) {
-    return null;
-  }
-
   const contextValue = useMemo(
     () => ({
       accessToken: session.accessToken,
@@ -226,6 +218,14 @@ export default function AuthGuard({ children, excludedPaths }) {
     }),
     [session, clearStoredSession, setUser],
   );
+
+  if (authState.checking) {
+    return <div>Loading...</div>;
+  }
+
+  if (!authState.authorized) {
+    return null;
+  }
 
   return (
     <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>

--- a/frontend/src/app/dashboard/history/[type]/[id]/page.jsx
+++ b/frontend/src/app/dashboard/history/[type]/[id]/page.jsx
@@ -21,7 +21,7 @@ const ChangeDetailsList = ({ details }) => {
   if (!Array.isArray(details) || details.length === 0) {
     return (
       <p className="text-sm text-slate-500">
-        ไม่มีรายละเอียดการเปลี่ยนแปลงเพิ่มเติมสำหรับรอบล่าสุด
+        No additional change details for the latest cycle
       </p>
     );
   }
@@ -32,7 +32,7 @@ const ChangeDetailsList = ({ details }) => {
         const key = detail.field || `${detail.label}-${index}`;
         const previous = detail.previous && detail.previous.length > 0 ? detail.previous : null;
         const current = detail.current && detail.current.length > 0 ? detail.current : null;
-        let value = "อัปเดต";
+        let value = "Updated";
 
         if (previous && current) {
           value = previous === current ? current : `${previous} → ${current}`;
@@ -75,7 +75,7 @@ const VersionDetailsList = ({ details, fallback }) => {
     );
   }
 
-  const fallbackText = fallback && fallback.length > 0 ? fallback : "ไม่มีข้อมูลเวอร์ชัน";
+  const fallbackText = fallback && fallback.length > 0 ? fallback : "No version data";
 
   return <p className="mt-4 text-sm text-slate-500">{fallbackText}</p>;
 };
@@ -115,12 +115,12 @@ const MaintenanceRecordDetailPage = ({ params }) => {
 
     if (wordpressResult.status === "rejected") {
       console.error("Unable to load WordPress sites:", wordpressResult.reason);
-      encounteredErrors.push("ไม่สามารถโหลดข้อมูล WordPress ได้");
+      encounteredErrors.push("Unable to load WordPress data.");
     }
 
     if (supportpalResult.status === "rejected") {
       console.error("Unable to load SupportPal sites:", supportpalResult.reason);
-      encounteredErrors.push("ไม่สามารถโหลดข้อมูล SupportPal ได้");
+      encounteredErrors.push("Unable to load SupportPal data.");
     }
 
     setData(nextData);
@@ -150,10 +150,10 @@ const MaintenanceRecordDetailPage = ({ params }) => {
     [combinedRecords, typeParam, idParam],
   );
 
-  const pageTitle = selectedRecord ? selectedRecord.name : "รายละเอียดระบบ";
+  const pageTitle = selectedRecord ? selectedRecord.name : "System details";
   const pageDescription = selectedRecord
-    ? `ดูข้อมูลการบำรุงรักษาและประวัติการอัปเดตของ ${selectedRecord.type}`
-    : "กำลังค้นหาข้อมูลระบบที่เลือก";
+    ? `Review maintenance history and updates for ${selectedRecord.type}`
+    : "Fetching the selected record";
 
   const lastCheckedLabel = selectedRecord
     ? formatDateTime(selectedRecord.lastCheckedDate)
@@ -161,8 +161,8 @@ const MaintenanceRecordDetailPage = ({ params }) => {
 
   const confirmationLabel = selectedRecord
     ? selectedRecord.isConfirmed
-      ? "ยืนยันการบำรุงรักษาแล้วในรอบปัจจุบัน"
-      : "ยังไม่ได้ยืนยันการบำรุงรักษาในรอบนี้"
+      ? "Confirmed for the current cycle"
+      : "Not yet confirmed this cycle"
     : "";
 
   return (
@@ -173,14 +173,14 @@ const MaintenanceRecordDetailPage = ({ params }) => {
         <div className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-end">
           {lastUpdated && (
             <span className="text-sm text-slate-600">
-              อัปเดตล่าสุด {formatDateTime(lastUpdated)}
+              Last updated {formatDateTime(lastUpdated)}
             </span>
           )}
           <Link
             href="/dashboard/history"
             className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white/80 px-5 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50"
           >
-            ← กลับไปหน้ารายการ
+            ← Back to list
           </Link>
           <button
             type="button"
@@ -188,7 +188,7 @@ const MaintenanceRecordDetailPage = ({ params }) => {
             disabled={isLoading}
             className="inline-flex items-center gap-2 rounded-full border border-[#316fb7] bg-[#316fb7] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[#245c94] disabled:cursor-not-allowed disabled:opacity-70"
           >
-            {isLoading ? "กำลังโหลด..." : "รีเฟรช"}
+            {isLoading ? "Loading..." : "Refresh"}
           </button>
         </div>
       }
@@ -224,10 +224,10 @@ const MaintenanceRecordDetailPage = ({ params }) => {
               </div>
               <div className="text-right text-sm text-slate-600">
                 <p className="font-medium uppercase tracking-wide text-slate-500">
-                  อัปเดตล่าสุด
+                  Last updated
                 </p>
                 <p className="mt-1 text-base font-semibold text-slate-900">
-                  {selectedRecord.lastActivityLabel || "ยังไม่มีประวัติ"}
+                  {selectedRecord.lastActivityLabel || "No history yet"}
                 </p>
               </div>
             </div>
@@ -243,26 +243,26 @@ const MaintenanceRecordDetailPage = ({ params }) => {
             )}
             <dl className="mt-4 grid gap-4 text-sm text-slate-600 sm:grid-cols-2">
               <div>
-                <dt className="font-medium text-slate-500">สถานะระบบ</dt>
-                <dd className="mt-1 text-slate-900">{selectedRecord.status || "ไม่ทราบ"}</dd>
+                <dt className="font-medium text-slate-500">System status</dt>
+                <dd className="mt-1 text-slate-900">{selectedRecord.status || "Unknown"}</dd>
               </div>
               <div>
-                <dt className="font-medium text-slate-500">ตรวจครั้งสุดท้าย</dt>
+                <dt className="font-medium text-slate-500">Last checked</dt>
                 <dd className="mt-1 text-slate-900">{lastCheckedLabel}</dd>
               </div>
               <div>
-                <dt className="font-medium text-slate-500">การยืนยันการบำรุงรักษา</dt>
+                <dt className="font-medium text-slate-500">Maintenance confirmation</dt>
                 <dd className="mt-1 text-slate-900">{confirmationLabel}</dd>
               </div>
               <div>
-                <dt className="font-medium text-slate-500">รหัสอ้างอิง</dt>
+                <dt className="font-medium text-slate-500">Reference ID</dt>
                 <dd className="mt-1 text-slate-900">{selectedRecord.id}</dd>
               </div>
             </dl>
           </div>
 
           <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-            <h3 className="text-lg font-semibold text-slate-900">รายละเอียดเวอร์ชัน</h3>
+            <h3 className="text-lg font-semibold text-slate-900">Version details</h3>
             <VersionDetailsList
               details={selectedRecord.versionDetails}
               fallback={selectedRecord.versionLabel || selectedRecord.version}
@@ -271,14 +271,14 @@ const MaintenanceRecordDetailPage = ({ params }) => {
 
           {selectedRecord.changeSummary && (
             <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-              <h3 className="text-lg font-semibold text-slate-900">สรุปการเปลี่ยนแปลงล่าสุด</h3>
+              <h3 className="text-lg font-semibold text-slate-900">Latest change summary</h3>
               <p className="mt-2 text-sm text-slate-600">{selectedRecord.changeSummary}</p>
             </div>
           )}
 
           {selectedRecord.maintenanceNotes && (
             <div className="rounded-2xl border border-amber-200 bg-amber-50/80 p-6 shadow-sm">
-              <h3 className="text-lg font-semibold text-amber-900">หมายเหตุการบำรุงรักษา</h3>
+              <h3 className="text-lg font-semibold text-amber-900">Maintenance notes</h3>
               <p className="mt-2 text-sm text-amber-800 leading-relaxed">
                 {selectedRecord.maintenanceNotes}
               </p>
@@ -286,9 +286,9 @@ const MaintenanceRecordDetailPage = ({ params }) => {
           )}
 
           <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-            <h3 className="text-lg font-semibold text-slate-900">รายละเอียดการเปลี่ยนแปลง</h3>
+            <h3 className="text-lg font-semibold text-slate-900">Change log details</h3>
             <p className="mt-2 text-sm text-slate-500">
-              รายการจากการตรวจพบการเปลี่ยนแปลงล่าสุด หากมีการอัปเดตหลายรายการจะเรียงตามลำดับที่ระบบแจ้งไว้
+              Entries reflect the most recent detected changes. If multiple updates occurred, they follow the order reported by the system.
             </p>
             <div className="mt-4">
               <ChangeDetailsList details={selectedRecord.changeDetails} />
@@ -298,7 +298,7 @@ const MaintenanceRecordDetailPage = ({ params }) => {
       ) : (
         <div className="mt-10 rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-10 text-center">
           <p className="text-sm text-slate-600">
-            ไม่พบข้อมูลระบบที่คุณเลือก อาจถูกลบหรือมีการเปลี่ยนรหัสอ้างอิง
+            The selected record could not be found. It may have been removed or the reference ID may have changed.
           </p>
         </div>
       )}

--- a/frontend/src/app/dashboard/history/page.jsx
+++ b/frontend/src/app/dashboard/history/page.jsx
@@ -110,28 +110,28 @@ const RecordSummaryCard = ({ record }) => {
               <span aria-hidden className="text-base leading-none">
                 •
               </span>
-              มีหมายเหตุ
+              Contains notes
             </span>
           )}
         </div>
         <div className="text-right text-sm text-slate-600">
           <p className="font-medium uppercase tracking-wide text-slate-500">
-            อัปเดตล่าสุด
+            Last updated
           </p>
           <p className="mt-1 text-base font-semibold text-slate-900">
-            {record.lastActivityLabel || "ยังไม่มีประวัติ"}
+            {record.lastActivityLabel || "No history yet"}
           </p>
         </div>
       </div>
 
       <dl className="mt-4 grid gap-4 text-sm text-slate-600 sm:grid-cols-2">
         <div>
-          <dt className="font-medium text-slate-500">เวอร์ชันล่าสุด</dt>
+          <dt className="font-medium text-slate-500">Latest version</dt>
           <dd className="mt-1 text-slate-900">{versionLabel}</dd>
         </div>
         <div>
-          <dt className="font-medium text-slate-500">สถานะระบบ</dt>
-          <dd className="mt-1 text-slate-900">{record.status || "ไม่ทราบ"}</dd>
+          <dt className="font-medium text-slate-500">System status</dt>
+          <dd className="mt-1 text-slate-900">{record.status || "Unknown"}</dd>
         </div>
       </dl>
 
@@ -140,7 +140,7 @@ const RecordSummaryCard = ({ record }) => {
       )}
 
       <div className="mt-5 inline-flex items-center gap-1 text-sm font-semibold text-[#316fb7]">
-        ดูรายละเอียด
+        View details
         <span aria-hidden className="transition group-hover:translate-x-0.5">
           →
         </span>
@@ -181,12 +181,12 @@ const MaintenanceHistoryPage = () => {
 
     if (wordpressResult.status === "rejected") {
       console.error("Unable to load WordPress sites:", wordpressResult.reason);
-      encounteredErrors.push("ไม่สามารถโหลดข้อมูล WordPress ได้");
+      encounteredErrors.push("Unable to load WordPress data.");
     }
 
     if (supportpalResult.status === "rejected") {
       console.error("Unable to load SupportPal sites:", supportpalResult.reason);
-      encounteredErrors.push("ไม่สามารถโหลดข้อมูล SupportPal ได้");
+      encounteredErrors.push("Unable to load SupportPal data.");
     }
 
     setData(nextData);
@@ -248,12 +248,12 @@ const MaintenanceHistoryPage = () => {
   return (
     <PageContainer
       title="Maintenance log"
-      description="ตรวจสอบข้อมูลเวอร์ชันและประวัติการอัปเดตของระบบทั้งหมดได้ในหน้าเดียว"
+      description="Review version information and update history for every system in one place."
       actions={
         <div className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-end">
           {lastUpdated && (
             <span className="text-sm text-slate-600">
-              อัปเดตล่าสุด {formatDateTime(lastUpdated)}
+              Last updated {formatDateTime(lastUpdated)}
             </span>
           )}
           <button
@@ -262,7 +262,7 @@ const MaintenanceHistoryPage = () => {
             disabled={isLoading}
             className="inline-flex items-center gap-2 rounded-full border border-[#316fb7] bg-white/80 px-5 py-2 text-sm font-semibold text-[#316fb7] shadow-sm transition hover:bg-[#316fb7]/10 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            {isLoading ? "กำลังโหลด..." : "รีเฟรช"}
+            {isLoading ? "Loading..." : "Refresh"}
           </button>
         </div>
       }
@@ -276,14 +276,14 @@ const MaintenanceHistoryPage = () => {
       <section className="mt-6 grid gap-4 md:grid-cols-3">
         <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
           <p className="text-sm font-semibold uppercase tracking-wide text-gray-500">
-            รายการทั้งหมด
+            Total records
           </p>
           <p className="mt-2 text-3xl font-bold text-gray-900">{stats.total}</p>
-          <p className="text-sm text-gray-500">จำนวนรายการที่กำลังติดตาม</p>
+          <p className="text-sm text-gray-500">Number of tracked entries</p>
         </div>
         <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
           <p className="text-sm font-semibold uppercase tracking-wide text-gray-500">
-            จำแนกตามระบบ
+            By platform
           </p>
           <ul className="mt-2 space-y-1 text-sm text-gray-600">
             {Object.entries(stats.byType).map(([type, count]) => (
@@ -293,18 +293,18 @@ const MaintenanceHistoryPage = () => {
               </li>
             ))}
             {Object.keys(stats.byType).length === 0 && (
-              <li className="text-gray-400">ยังไม่มีข้อมูล</li>
+              <li className="text-gray-400">No data yet</li>
             )}
           </ul>
         </div>
         <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
           <p className="text-sm font-semibold uppercase tracking-wide text-gray-500">
-            การอัปเดตล่าสุด
+            Latest confirmation
           </p>
           <p className="mt-2 text-lg font-semibold text-gray-900">
-            {stats.latest ? stats.latest.label : "ยังไม่มีประวัติ"}
+            {stats.latest ? stats.latest.label : "No history yet"}
           </p>
-          <p className="text-sm text-gray-500">ข้อมูลอ้างอิงตามเวลาที่ตรวจพบการเปลี่ยนแปลง</p>
+          <p className="text-sm text-gray-500">Based on when the most recent change was detected</p>
         </div>
       </section>
 
@@ -313,20 +313,20 @@ const MaintenanceHistoryPage = () => {
           <div className="flex flex-1 flex-col gap-3 sm:flex-row sm:items-end">
             <div className="flex-1">
               <label className="block text-sm font-medium text-gray-700" htmlFor="maintenance-search">
-                ค้นหาระบบ
+                Search systems
               </label>
               <input
                 id="maintenance-search"
                 type="search"
                 value={searchTerm}
                 onChange={(event) => setSearchTerm(event.target.value)}
-                placeholder="ค้นหาด้วยชื่อระบบ เวอร์ชัน หรือหมายเหตุ"
+                placeholder="Search by system name, version, or note"
                 className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm shadow-sm focus:border-[#316fb7] focus:outline-none focus:ring-2 focus:ring-[#316fb7]/40"
               />
             </div>
             <div className="w-full sm:w-56">
               <label className="block text-sm font-medium text-gray-700" htmlFor="maintenance-type-filter">
-                เลือกระบบ
+                Filter by platform
               </label>
               <select
                 id="maintenance-type-filter"
@@ -343,7 +343,7 @@ const MaintenanceHistoryPage = () => {
             </div>
           </div>
           <div className="text-sm text-gray-500">
-            แสดง {filteredRecords.length} จาก {combinedRecords.length} รายการ
+            Showing {filteredRecords.length} of {combinedRecords.length} records
           </div>
         </div>
 
@@ -358,7 +358,7 @@ const MaintenanceHistoryPage = () => {
           </div>
         ) : filteredRecords.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-10 text-center">
-            <p className="text-sm text-gray-500">ไม่พบข้อมูลที่ตรงกับเงื่อนไขที่เลือก</p>
+            <p className="text-sm text-gray-500">No records match the selected filters</p>
           </div>
         ) : (
           <ul className="grid gap-4 lg:grid-cols-2">

--- a/frontend/src/app/dashboard/page.jsx
+++ b/frontend/src/app/dashboard/page.jsx
@@ -1,8 +1,10 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
 
 import PageContainer from "../components/PageContainer";
+import { fetchSupportpalSites, fetchWordpressSites } from "../lib/api";
 
 const quickLinks = [
   {
@@ -27,6 +29,274 @@ const quickLinks = [
     icon: "support_agent",
   },
 ];
+
+const PLATFORMS = [
+  { key: "wordpress", name: "WordPress" },
+  { key: "supportpal", name: "SupportPal" },
+];
+
+const createEmptyStats = () => ({
+  total: 0,
+  confirmed: 0,
+  pending: 0,
+  pendingNames: [],
+  confirmedNames: [],
+});
+
+const createInitialStats = () => ({
+  wordpress: createEmptyStats(),
+  supportpal: createEmptyStats(),
+});
+
+const truthyStrings = new Set([
+  "true",
+  "1",
+  "t",
+  "y",
+  "yes",
+  "done",
+  "complete",
+  "completed",
+  "confirmed",
+]);
+
+const falsyStrings = new Set(["false", "0", "f", "n", "no", "pending", "incomplete"]);
+
+const normaliseConfirmation = (value) => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return value !== 0;
+  }
+
+  if (typeof value === "string") {
+    const normalised = value.trim().toLowerCase();
+
+    if (truthyStrings.has(normalised)) {
+      return true;
+    }
+
+    if (falsyStrings.has(normalised)) {
+      return false;
+    }
+  }
+
+  return false;
+};
+
+const deriveSiteName = (site, index) => {
+  if (site?.name && typeof site.name === "string" && site.name.trim()) {
+    return site.name.trim();
+  }
+
+  if (site?.url && typeof site.url === "string" && site.url.trim()) {
+    return site.url.trim();
+  }
+
+  return `Entry ${index + 1}`;
+};
+
+const buildMaintenanceStats = (sites = []) => {
+  const stats = createEmptyStats();
+  const list = Array.isArray(sites) ? sites : [];
+
+  stats.total = list.length;
+
+  list.forEach((site, index) => {
+    const rawStatus = site?.isConfirmed ?? site?.is_confirmed;
+    const isConfirmed = normaliseConfirmation(rawStatus);
+    const displayName = deriveSiteName(site, index);
+
+    if (isConfirmed) {
+      stats.confirmed += 1;
+      stats.confirmedNames.push(displayName);
+      return;
+    }
+
+    stats.pending += 1;
+    stats.pendingNames.push(displayName);
+  });
+
+  return stats;
+};
+
+const extractErrorMessage = (error, fallbackMessage) => {
+  if (!error) {
+    return fallbackMessage;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  if (typeof error === "string" && error.trim()) {
+    return error.trim();
+  }
+
+  return fallbackMessage;
+};
+
+const summariseNames = (names = [], limit = 4) => {
+  if (!Array.isArray(names) || names.length === 0) {
+    return [];
+  }
+
+  const trimmed = names
+    .map((name) => (typeof name === "string" ? name.trim() : ""))
+    .filter(Boolean);
+
+  if (trimmed.length <= limit) {
+    return trimmed;
+  }
+
+  const visible = trimmed.slice(0, limit - 1);
+  const remaining = trimmed.length - visible.length;
+
+  return [...visible, `+${remaining} more`];
+};
+
+const getCompletionPercentage = (confirmed, total) => {
+  if (!total) {
+    return 0;
+  }
+
+  const percentage = Math.round((confirmed / total) * 100);
+  return Math.min(100, Math.max(0, percentage));
+};
+
+const ProgressRing = ({ confirmed, total, label, size = 88 }) => {
+  const percentage = getCompletionPercentage(confirmed, total);
+  const innerOffset = Math.max(6, Math.round(size * 0.2));
+
+  return (
+    <div
+      className="relative flex items-center justify-center"
+      style={{ width: size, height: size }}
+      role="img"
+      aria-label={label || `${confirmed} of ${total || 0} maintenance tasks confirmed (${percentage}%)`}
+    >
+      <div
+        className="absolute inset-0 rounded-full"
+        style={{
+          background: `conic-gradient(#22c55e ${percentage}%, rgba(148, 163, 184, 0.35) ${percentage}% 100%)`,
+        }}
+      />
+      <div
+        className="absolute rounded-full bg-white"
+        style={{ inset: innerOffset }}
+        aria-hidden
+      />
+      <span className="relative text-xs font-semibold text-slate-900">
+        {confirmed}/{total || 0}
+      </span>
+    </div>
+  );
+};
+
+const PlatformSummaryCard = ({ platform, stats, error, isLoading }) => {
+  if (isLoading) {
+    return (
+      <div className="rounded-2xl border border-slate-100 bg-white/70 p-4 shadow-sm">
+        <div className="flex items-center gap-4">
+          <div className="h-16 w-16 animate-pulse rounded-full bg-slate-100" />
+          <div className="flex-1 space-y-3">
+            <div className="h-3 w-28 rounded-full bg-slate-100" />
+            <div className="h-3 w-40 rounded-full bg-slate-100" />
+            <div className="h-3 w-24 rounded-full bg-slate-100" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-amber-200 bg-amber-50/80 p-4 text-sm text-amber-700 shadow-sm">
+        <p className="font-semibold">{platform.name}</p>
+        <p className="mt-1 leading-relaxed">{error}</p>
+        <p className="mt-2 text-xs text-amber-600">
+          Open the {platform.name} workspace to retry loading maintenance status.
+        </p>
+      </div>
+    );
+  }
+
+  const { total, confirmed, pending, pendingNames, confirmedNames } = stats;
+  const pendingDisplay = summariseNames(pendingNames);
+  const confirmedDisplay = summariseNames(confirmedNames);
+  const percentage = getCompletionPercentage(confirmed, total);
+
+  const statusMessage = (() => {
+    if (!total) {
+      return "No maintenance records yet.";
+    }
+
+    if (pending === 0) {
+      return "All maintenance confirmed.";
+    }
+
+    return `${pending} awaiting confirmation.`;
+  })();
+
+  return (
+    <div className="rounded-2xl border border-slate-100 bg-white/70 p-4 shadow-sm">
+      <div className="flex items-start gap-4">
+        <ProgressRing
+          confirmed={confirmed}
+          total={total}
+          label={`${platform.name}: ${confirmed} of ${total || 0} confirmed (${percentage}%)`}
+          size={80}
+        />
+        <div className="flex-1">
+          <p className="text-sm font-semibold text-slate-900">{platform.name}</p>
+          <p className="mt-1 text-xs text-slate-600">{statusMessage}</p>
+          <p className="mt-2 text-xs text-slate-500">
+            <span className="font-semibold text-emerald-600">{confirmed}</span> confirmed ·{" "}
+            <span className="font-semibold text-amber-600">{pending}</span> pending
+          </p>
+
+          {pendingDisplay.length > 0 && (
+            <div className="mt-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-amber-600">
+                Waiting for confirmation
+              </p>
+              <ul className="mt-1 flex flex-wrap gap-1">
+                {pendingDisplay.map((name, index) => (
+                  <li
+                    key={`${platform.key}-pending-${index}`}
+                    className="rounded-full bg-amber-100 px-2.5 py-1 text-[11px] font-medium text-amber-700"
+                  >
+                    {name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {confirmedDisplay.length > 0 && (
+            <div className="mt-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-emerald-600">
+                Completed confirmations
+              </p>
+              <ul className="mt-1 flex flex-wrap gap-1">
+                {confirmedDisplay.map((name, index) => (
+                  <li
+                    key={`${platform.key}-confirmed-${index}`}
+                    className="rounded-full bg-emerald-100 px-2.5 py-1 text-[11px] font-medium text-emerald-700"
+                  >
+                    {name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
 
 const NavigatorCard = ({ title, description, href, icon }) => (
   <Link
@@ -54,6 +324,94 @@ const NavigatorCard = ({ title, description, href, icon }) => (
 );
 
 const DashboardPage = () => {
+  const [maintenanceStats, setMaintenanceStats] = useState(() => createInitialStats());
+  const [maintenanceErrors, setMaintenanceErrors] = useState({ wordpress: null, supportpal: null });
+  const [isLoadingStats, setIsLoadingStats] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadStats = async () => {
+      setIsLoadingStats(true);
+
+      const [wpResult, spResult] = await Promise.allSettled([
+        fetchWordpressSites(),
+        fetchSupportpalSites(),
+      ]);
+
+      if (!isMounted) {
+        return;
+      }
+
+      const nextStats = createInitialStats();
+      const nextErrors = { wordpress: null, supportpal: null };
+
+      if (wpResult.status === "fulfilled") {
+        nextStats.wordpress = buildMaintenanceStats(wpResult.value);
+      } else {
+        nextErrors.wordpress = extractErrorMessage(
+          wpResult.reason,
+          "Unable to load WordPress maintenance status."
+        );
+      }
+
+      if (spResult.status === "fulfilled") {
+        nextStats.supportpal = buildMaintenanceStats(spResult.value);
+      } else {
+        nextErrors.supportpal = extractErrorMessage(
+          spResult.reason,
+          "Unable to load SupportPal maintenance status."
+        );
+      }
+
+      setMaintenanceStats(nextStats);
+      setMaintenanceErrors(nextErrors);
+      setIsLoadingStats(false);
+    };
+
+    loadStats();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const aggregatedStats = useMemo(
+    () =>
+      Object.values(maintenanceStats).reduce(
+        (acc, stats) => {
+          acc.total += stats.total;
+          acc.confirmed += stats.confirmed;
+          acc.pending += stats.pending;
+          return acc;
+        },
+        { total: 0, confirmed: 0, pending: 0 }
+      ),
+    [maintenanceStats]
+  );
+
+  const aggregatedPercentage = getCompletionPercentage(
+    aggregatedStats.confirmed,
+    aggregatedStats.total
+  );
+
+  const aggregatedMessage = useMemo(() => {
+    if (isLoadingStats) {
+      return "Loading maintenance progress…";
+    }
+
+    if (!aggregatedStats.total) {
+      return "Add your first maintenance record to begin tracking progress.";
+    }
+
+    if (aggregatedStats.pending === 0) {
+      return "All maintenance across WordPress and SupportPal is confirmed.";
+    }
+
+    const plural = aggregatedStats.pending === 1 ? "" : "s";
+    return `${aggregatedStats.pending} pending confirmation${plural} across all platforms.`;
+  }, [aggregatedStats, isLoadingStats]);
+
   return (
     <PageContainer
       meta="Navigator"
@@ -71,6 +429,46 @@ const DashboardPage = () => {
           This page serves as a shortcut to every part of the maintenance ecosystem—select a destination and start reviewing
           without repeating the same searches.
         </p>
+      </section>
+
+      <section className="mt-8 rounded-3xl bg-white/80 p-8 shadow-lg backdrop-blur">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex items-center gap-4">
+            {isLoadingStats ? (
+              <div className="h-24 w-24 animate-pulse rounded-full bg-slate-100" />
+            ) : (
+              <ProgressRing
+                confirmed={aggregatedStats.confirmed}
+                total={aggregatedStats.total}
+                label={`Overall: ${aggregatedStats.confirmed} of ${aggregatedStats.total || 0} confirmed (${aggregatedPercentage}%)`}
+                size={110}
+              />
+            )}
+            <div>
+              <h3 className="text-xl font-semibold text-slate-900">Today&apos;s maintenance status</h3>
+              <p className="mt-1 text-sm text-slate-600">
+                Review outstanding confirmations before diving into a specific platform.
+              </p>
+              <p className="mt-3 text-sm text-slate-900">
+                <span className="font-semibold text-emerald-600">{aggregatedStats.confirmed}</span>
+                /{aggregatedStats.total || 0} tasks confirmed
+              </p>
+              <p className="mt-1 text-sm text-slate-600">{aggregatedMessage}</p>
+            </div>
+          </div>
+
+          <div className="grid flex-1 gap-4 md:grid-cols-2">
+            {PLATFORMS.map((platform) => (
+              <PlatformSummaryCard
+                key={platform.key}
+                platform={platform}
+                stats={maintenanceStats[platform.key] ?? createEmptyStats()}
+                error={maintenanceErrors[platform.key]}
+                isLoading={isLoadingStats}
+              />
+            ))}
+          </div>
+        </div>
       </section>
 
       <section className="mt-8">

--- a/frontend/src/app/dashboard/page.jsx
+++ b/frontend/src/app/dashboard/page.jsx
@@ -8,21 +8,21 @@ const quickLinks = [
   {
     title: "Maintenance log",
     description:
-      "ดูประวัติการอัปเดตทั้งหมดของแต่ละระบบ รวมถึงรายละเอียดเวอร์ชันและบันทึกงานซ่อมบำรุง.",
+      "Review every update recorded for each platform, including version history and maintenance notes.",
     href: "/dashboard/history",
     icon: "history",
   },
   {
-    title: "ระบบ WordPress",
+    title: "WordPress platform",
     description:
-      "เข้าถึงพื้นที่สำหรับตรวจสอบปลั๊กอิน ธีม และเวอร์ชัน WordPress ที่มีอยู่ทั้งหมด.",
+      "Inspect all active plugins, themes, and WordPress versions from a single workspace.",
     href: "/WordPress",
     icon: "language",
   },
   {
-    title: "ระบบ SupportPal",
+    title: "SupportPal platform",
     description:
-      "ติดตามสถานะและบันทึกการดูแลรักษาของ SupportPal ในแต่ละสาขา.",
+      "Track SupportPal health, confirmation status, and maintenance records across every branch.",
     href: "/Supportpal",
     icon: "support_agent",
   },
@@ -45,7 +45,7 @@ const NavigatorCard = ({ title, description, href, icon }) => (
       </div>
     </div>
     <span className="mt-6 inline-flex items-center gap-1 text-sm font-semibold text-[#316fb7]">
-      เปิดหน้าดังกล่าว
+      Open this section
       <span aria-hidden className="transition group-hover:translate-x-0.5">
         →
       </span>
@@ -58,27 +58,27 @@ const DashboardPage = () => {
     <PageContainer
       meta="Navigator"
       title="Maintenance workspace"
-      description="เลือกปลายทางที่ต้องการดูแลรักษาเพื่อเริ่มต้นทำงานได้อย่างรวดเร็ว"
+      description="Pick a destination to begin maintenance work right away."
     >
       <section className="rounded-3xl bg-gradient-to-br from-[#1e3a64] via-[#1a2e52] to-[#13213c] p-8 text-white shadow-lg">
         <p className="text-sm font-semibold uppercase tracking-wide text-white/70">
           Welcome back, Admin!
         </p>
         <h2 className="mt-2 text-3xl font-bold">
-          เลือกแพลตฟอร์มที่คุณต้องการดูแลในวันนี้
+          Choose the platform you want to maintain today
         </h2>
         <p className="mt-4 max-w-3xl text-sm text-white/80">
-          หน้านี้ออกแบบมาเพื่อเป็นทางลัดไปยังส่วนต่าง ๆ ของระบบดูแลรักษา
-          ไม่ต้องค้นหาข้อมูลซ้ำซ้อน — เลือกปลายทางที่ต้องการแล้วเริ่มตรวจสอบได้เลย
+          This page serves as a shortcut to every part of the maintenance ecosystem—select a destination and start reviewing
+          without repeating the same searches.
         </p>
       </section>
 
       <section className="mt-8">
         <div className="flex items-center justify-between gap-4">
           <div>
-            <h2 className="text-lg font-semibold text-slate-900">ส่วนหลักของการดูแล</h2>
+            <h2 className="text-lg font-semibold text-slate-900">Core maintenance areas</h2>
             <p className="mt-1 text-sm text-slate-600">
-              เข้าถึงหน้าสำคัญที่ใช้ตรวจสอบบันทึกและรายละเอียดการดูแลทั้งหมด.
+              Access the essential pages for reviewing records, confirmations, and follow-up tasks.
             </p>
           </div>
         </div>

--- a/frontend/src/app/layout.js
+++ b/frontend/src/app/layout.js
@@ -22,7 +22,7 @@ export default function RootLayout({ children }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const pathname = usePathname();
 
-  // หน้าที่ไม่ต้องการ Sidebar และไม่ต้องการ AuthGuard
+  // Pages that do not require the sidebar or authentication guard
   const noSidebarPages = ['/login', '/register', '/forgot-password'];
   const shouldShowSidebar = !noSidebarPages.includes(pathname);
   const shouldProtect = !noSidebarPages.includes(pathname);

--- a/frontend/src/app/layout.js
+++ b/frontend/src/app/layout.js
@@ -52,6 +52,37 @@ export default function RootLayout({ children }) {
     }
   }, [isDesktop]);
 
+  const mainClassName = [
+    "transition-all duration-300 w-full flex-1",
+    shouldShowSidebar
+      ? isDesktop
+        ? sidebarOpen
+          ? "lg:ml-64"
+          : "lg:ml-16"
+        : "ml-0"
+      : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const layoutContent = (
+    <>
+      {shouldShowSidebar && (
+        <NavSidebar
+          isDesktop={isDesktop}
+          isOpen={sidebarOpen}
+          setIsOpen={setSidebarOpen}
+        />
+      )}
+
+      <main className={mainClassName}>
+        <PageTransition>
+          <div className="min-h-screen w-full">{children}</div>
+        </PageTransition>
+      </main>
+    </>
+  );
+
   return (
     <html lang="en">
       <head>
@@ -72,50 +103,7 @@ export default function RootLayout({ children }) {
           ${!shouldShowSidebar ? 'overflow-hidden' : ''}
         `}
       >
-        {shouldShowSidebar && (
-          <NavSidebar
-            isDesktop={isDesktop}
-            isOpen={sidebarOpen}
-            setIsOpen={setSidebarOpen}
-          />
-        )}
-
-        {shouldProtect ? (
-          <AuthGuard>
-            <main
-              className={`transition-all duration-300 w-full flex-1 ${
-                shouldShowSidebar
-                  ? isDesktop
-                    ? sidebarOpen
-                      ? 'lg:ml-64'
-                      : 'lg:ml-16'
-                    : 'ml-0'
-                  : ''
-              }`}
-            >
-              <PageTransition>
-                <div className="min-h-screen w-full">{children}</div>
-              </PageTransition>
-            </main>
-          </AuthGuard >
-        ) : (
-          <main
-            className={`transition-all duration-300 w-full flex-1 ${
-              shouldShowSidebar
-                ? isDesktop
-                  ? sidebarOpen
-                    ? 'lg:ml-64'
-                    : 'lg:ml-16'
-                  : 'ml-0'
-                : ''
-            }`}
-          >
-            <PageTransition>
-              <div className="min-h-screen w-full">{children}</div>
-            </PageTransition>
-          </main>
-        )}
-
+        {shouldProtect ? <AuthGuard>{layoutContent}</AuthGuard> : layoutContent}
       </body>
     </html>
   );

--- a/frontend/src/app/lib/auth-context.js
+++ b/frontend/src/app/lib/auth-context.js
@@ -1,0 +1,17 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+const AuthContext = createContext(undefined);
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+
+  return context;
+};
+
+export default AuthContext;

--- a/frontend/src/app/page.js
+++ b/frontend/src/app/page.js
@@ -2,14 +2,18 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
 
 import PageContainer from "./components/PageContainer";
+import { fetchSupportpalSites, fetchWordpressSites } from "./lib/api";
 import { useAuth } from "./lib/auth-context";
 
 const SERVICES = [
   {
+    key: "wordpress",
     name: "WordPress",
-    description: "Review plugin updates, confirm content deployments, and track maintenance history for each site.",
+    description:
+      "Review plugin updates, confirm content deployments, and track maintenance history for each site.",
     href: "/WordPress",
     badge: "Weekly resets • Mondays 00:00 (Asia/Bangkok)",
     image: {
@@ -19,8 +23,10 @@ const SERVICES = [
     gradient: "from-[#f0f6ff] to-white",
   },
   {
+    key: "supportpal",
     name: "SupportPal",
-    description: "Monitor ticketing infrastructure, confirm server updates, and document follow-up actions.",
+    description:
+      "Monitor ticketing infrastructure, confirm server updates, and document follow-up actions.",
     href: "/Supportpal",
     badge: "Monthly resets • 1st day 00:00 (Asia/Bangkok)",
     image: {
@@ -31,27 +37,439 @@ const SERVICES = [
   },
 ];
 
+const createEmptyStats = () => ({
+  total: 0,
+  confirmed: 0,
+  pending: 0,
+  pendingNames: [],
+  confirmedNames: [],
+});
+
+const createInitialStats = () => ({
+  wordpress: createEmptyStats(),
+  supportpal: createEmptyStats(),
+});
+
+const truthyStrings = new Set([
+  "true",
+  "1",
+  "t",
+  "y",
+  "yes",
+  "done",
+  "complete",
+  "completed",
+  "confirmed",
+]);
+
+const falsyStrings = new Set(["false", "0", "f", "n", "no", "pending", "incomplete"]);
+
+const normaliseConfirmation = (value) => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return value !== 0;
+  }
+
+  if (typeof value === "string") {
+    const normalised = value.trim().toLowerCase();
+
+    if (truthyStrings.has(normalised)) {
+      return true;
+    }
+
+    if (falsyStrings.has(normalised)) {
+      return false;
+    }
+  }
+
+  return false;
+};
+
+const deriveSiteName = (site, index) => {
+  if (site?.name && typeof site.name === "string" && site.name.trim()) {
+    return site.name.trim();
+  }
+
+  if (site?.url && typeof site.url === "string" && site.url.trim()) {
+    return site.url.trim();
+  }
+
+  return `Entry ${index + 1}`;
+};
+
+const buildMaintenanceStats = (sites = []) => {
+  const stats = createEmptyStats();
+  const list = Array.isArray(sites) ? sites : [];
+
+  stats.total = list.length;
+
+  list.forEach((site, index) => {
+    const rawStatus = site?.isConfirmed ?? site?.is_confirmed;
+    const isConfirmed = normaliseConfirmation(rawStatus);
+    const displayName = deriveSiteName(site, index);
+
+    if (isConfirmed) {
+      stats.confirmed += 1;
+      stats.confirmedNames.push(displayName);
+      return;
+    }
+
+    stats.pending += 1;
+    stats.pendingNames.push(displayName);
+  });
+
+  return stats;
+};
+
+const extractErrorMessage = (error, fallbackMessage) => {
+  if (!error) {
+    return fallbackMessage;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  if (typeof error === "string" && error.trim()) {
+    return error.trim();
+  }
+
+  return fallbackMessage;
+};
+
+const summariseNames = (names = [], limit = 4) => {
+  if (!Array.isArray(names) || names.length === 0) {
+    return [];
+  }
+
+  const trimmed = names
+    .map((name) => (typeof name === "string" ? name.trim() : ""))
+    .filter(Boolean);
+
+  if (trimmed.length <= limit) {
+    return trimmed;
+  }
+
+  const visible = trimmed.slice(0, limit - 1);
+  const remaining = trimmed.length - visible.length;
+
+  return [...visible, `+${remaining} more`];
+};
+
+const getCompletionPercentage = (confirmed, total) => {
+  if (!total) {
+    return 0;
+  }
+
+  const percentage = Math.round((confirmed / total) * 100);
+  return Math.min(100, Math.max(0, percentage));
+};
+
+const ProgressRing = ({ confirmed, total, label, size = 88 }) => {
+  const percentage = getCompletionPercentage(confirmed, total);
+  const innerOffset = Math.max(6, Math.round(size * 0.2));
+
+  return (
+    <div
+      className="relative flex items-center justify-center"
+      style={{ width: size, height: size }}
+      role="img"
+      aria-label={
+        label || `${confirmed} of ${total || 0} maintenance tasks confirmed (${percentage}%)`
+      }
+    >
+      <div
+        className="absolute inset-0 rounded-full"
+        style={{
+          background: `conic-gradient(#22c55e ${percentage}%, rgba(148, 163, 184, 0.35) ${percentage}% 100%)`,
+        }}
+      />
+      <div
+        className="absolute rounded-full bg-white"
+        style={{ inset: innerOffset }}
+        aria-hidden
+      />
+      <span className="relative text-xs font-semibold text-slate-900">
+        {confirmed}/{total || 0}
+      </span>
+    </div>
+  );
+};
+
+const PlatformSummaryCard = ({ service, stats, error, isLoading }) => {
+  if (isLoading) {
+    return (
+      <div className="rounded-2xl border border-slate-100 bg-white/70 p-4 shadow-sm">
+        <div className="flex items-center gap-4">
+          <div className="h-16 w-16 animate-pulse rounded-full bg-slate-100" />
+          <div className="flex-1 space-y-3">
+            <div className="h-3 w-28 rounded-full bg-slate-100" />
+            <div className="h-3 w-40 rounded-full bg-slate-100" />
+            <div className="h-3 w-24 rounded-full bg-slate-100" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-amber-200 bg-amber-50/80 p-4 text-sm text-amber-700 shadow-sm">
+        <p className="font-semibold">{service.name}</p>
+        <p className="mt-1 leading-relaxed">{error}</p>
+        <p className="mt-2 text-xs text-amber-600">
+          Open the {service.name} workspace to retry loading maintenance status.
+        </p>
+      </div>
+    );
+  }
+
+  const { total, confirmed, pending, pendingNames, confirmedNames } = stats;
+  const pendingDisplay = summariseNames(pendingNames);
+  const confirmedDisplay = summariseNames(confirmedNames);
+  const percentage = getCompletionPercentage(confirmed, total);
+
+  const statusMessage = (() => {
+    if (!total) {
+      return "No maintenance records yet.";
+    }
+
+    if (pending === 0) {
+      return "All maintenance confirmed.";
+    }
+
+    return `${pending} awaiting confirmation.`;
+  })();
+
+  return (
+    <div className="rounded-2xl border border-slate-100 bg-white/70 p-4 shadow-sm">
+      <div className="flex items-start gap-4">
+        <ProgressRing
+          confirmed={confirmed}
+          total={total}
+          label={`${service.name}: ${confirmed} of ${total || 0} confirmed (${percentage}%)`}
+          size={80}
+        />
+        <div className="flex-1">
+          <p className="text-sm font-semibold text-slate-900">{service.name}</p>
+          <p className="mt-1 text-xs text-slate-600">{statusMessage}</p>
+          <p className="mt-2 text-xs text-slate-500">
+            <span className="font-semibold text-emerald-600">{confirmed}</span> confirmed ·{" "}
+            <span className="font-semibold text-amber-600">{pending}</span> pending
+          </p>
+
+          {pendingDisplay.length > 0 && (
+            <div className="mt-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-amber-600">
+                Waiting for confirmation
+              </p>
+              <ul className="mt-1 flex flex-wrap gap-1">
+                {pendingDisplay.map((name, index) => (
+                  <li
+                    key={`${service.key}-pending-${index}`}
+                    className="rounded-full bg-amber-100 px-2.5 py-1 text-[11px] font-medium text-amber-700"
+                  >
+                    {name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {confirmedDisplay.length > 0 && (
+            <div className="mt-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-emerald-600">
+                Completed confirmations
+              </p>
+              <ul className="mt-1 flex flex-wrap gap-1">
+                {confirmedDisplay.map((name, index) => (
+                  <li
+                    key={`${service.key}-confirmed-${index}`}
+                    className="rounded-full bg-emerald-100 px-2.5 py-1 text-[11px] font-medium text-emerald-700"
+                  >
+                    {name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
 const Home = () => {
   const { user } = useAuth();
 
-  const greetingName = [user?.firstname, user?.username, user?.email]
-    .find((value) => typeof value === "string" && value.trim().length > 0);
+  const [maintenanceStats, setMaintenanceStats] = useState(() => createInitialStats());
+  const [maintenanceErrors, setMaintenanceErrors] = useState({ wordpress: null, supportpal: null });
+  const [isLoadingStats, setIsLoadingStats] = useState(true);
+
+  const greetingName = [user?.firstname, user?.username, user?.email].find(
+    (value) => typeof value === "string" && value.trim().length > 0
+  );
 
   const safeGreeting = greetingName ? greetingName.trim() : "";
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadStats = async () => {
+      setIsLoadingStats(true);
+
+      const [wpResult, spResult] = await Promise.allSettled([
+        fetchWordpressSites(),
+        fetchSupportpalSites(),
+      ]);
+
+      if (!isMounted) {
+        return;
+      }
+
+      const nextStats = createInitialStats();
+      const nextErrors = { wordpress: null, supportpal: null };
+
+      if (wpResult.status === "fulfilled") {
+        nextStats.wordpress = buildMaintenanceStats(wpResult.value);
+      } else {
+        nextErrors.wordpress = extractErrorMessage(
+          wpResult.reason,
+          "Unable to load WordPress maintenance status."
+        );
+      }
+
+      if (spResult.status === "fulfilled") {
+        nextStats.supportpal = buildMaintenanceStats(spResult.value);
+      } else {
+        nextErrors.supportpal = extractErrorMessage(
+          spResult.reason,
+          "Unable to load SupportPal maintenance status."
+        );
+      }
+
+      setMaintenanceStats(nextStats);
+      setMaintenanceErrors(nextErrors);
+      setIsLoadingStats(false);
+    };
+
+    loadStats();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const aggregatedStats = useMemo(
+    () =>
+      Object.values(maintenanceStats).reduce(
+        (acc, stats) => {
+          acc.total += stats.total;
+          acc.confirmed += stats.confirmed;
+          acc.pending += stats.pending;
+          return acc;
+        },
+        { total: 0, confirmed: 0, pending: 0 }
+      ),
+    [maintenanceStats]
+  );
+
+  const aggregatedPercentage = getCompletionPercentage(
+    aggregatedStats.confirmed,
+    aggregatedStats.total
+  );
+
+  const aggregatedMessage = useMemo(() => {
+    if (isLoadingStats) {
+      return "Loading maintenance progress…";
+    }
+
+    if (!aggregatedStats.total) {
+      return "Add your first maintenance record to begin tracking progress.";
+    }
+
+    if (aggregatedStats.pending === 0) {
+      return "All maintenance across WordPress and SupportPal is confirmed.";
+    }
+
+    const plural = aggregatedStats.pending === 1 ? "" : "s";
+    return `${aggregatedStats.pending} pending confirmation${plural} across all platforms.`;
+  }, [aggregatedStats, isLoadingStats]);
+
+  const getServiceStatus = (serviceKey) => {
+    const stats = maintenanceStats[serviceKey] ?? createEmptyStats();
+
+    if (isLoadingStats) {
+      return {
+        type: "loading",
+        headline: "Loading status…",
+        description: "",
+        stats,
+      };
+    }
+
+    const error = maintenanceErrors[serviceKey];
+    if (error) {
+      return {
+        type: "error",
+        headline: "Status unavailable",
+        description: error,
+        stats,
+      };
+    }
+
+    if (!stats.total) {
+      return {
+        type: "info",
+        headline: "No maintenance records yet.",
+        description: "Start by adding a site to begin tracking progress.",
+        stats,
+      };
+    }
+
+    if (stats.pending === 0) {
+      return {
+        type: "success",
+        headline: "All maintenance confirmed.",
+        description: "Everything is up to date for this cycle.",
+        stats,
+      };
+    }
+
+    const plural = stats.pending === 1 ? "" : "s";
+    return {
+      type: "warning",
+      headline: `${stats.pending} pending confirmation${plural}.`,
+      description: "Review outstanding records before you proceed.",
+      stats,
+    };
+  };
+
+  const statusToneToDot = {
+    loading: "bg-slate-300",
+    error: "bg-amber-600",
+    info: "bg-slate-400",
+    success: "bg-emerald-500",
+    warning: "bg-amber-500",
+  };
 
   return (
     <PageContainer
       meta="Maintenance workspace"
       title={`Welcome back${safeGreeting ? ", " + safeGreeting : ""}!`}
       description="Choose the platform you would like to maintain. Everything shares the same visual language so you can move between systems with confidence."
-      actions={(
+      actions={
         <div className="rounded-2xl bg-white/70 px-6 py-4 text-sm text-slate-600 shadow-sm backdrop-blur">
           <p className="font-semibold text-[#316fb7]">Today&apos;s reminder</p>
           <p className="mt-1 leading-relaxed">
-            Confirm WordPress updates by Monday midnight and SupportPal updates by the first of each month. Keeping confirmations up to date helps everyone stay in sync.
+            Confirm WordPress updates by Monday midnight and SupportPal updates by the first of each
+            month. Keeping confirmations up to date helps everyone stay in sync.
           </p>
         </div>
-      )}
+      }
       maxWidth="max-w-6xl"
     >
       <section className="grid gap-6 lg:grid-cols-[1.2fr_1fr]">
@@ -59,11 +477,14 @@ const Home = () => {
           <div className="rounded-3xl bg-white/80 p-8 shadow-lg backdrop-blur">
             <h2 className="text-2xl font-semibold text-slate-900">Your maintenance hub</h2>
             <p className="mt-3 text-base leading-relaxed text-slate-600">
-              Stay on top of every release cycle with a unified, familiar interface. Jump directly into a platform or review the combined health metrics from the dashboard.
+              Stay on top of every release cycle with a unified, familiar interface. Jump directly
+              into a platform or review the combined health metrics from the dashboard.
             </p>
             <div className="mt-6 grid gap-3 text-sm text-slate-600 sm:grid-cols-2">
               <div className="rounded-2xl border border-slate-100 bg-slate-50/60 p-4">
-                <p className="text-xs font-semibold uppercase tracking-wider text-[#316fb7]">Quick access</p>
+                <p className="text-xs font-semibold uppercase tracking-wider text-[#316fb7]">
+                  Quick access
+                </p>
                 <p className="mt-2 font-medium text-slate-900">Dashboard overview</p>
                 <p className="mt-1 text-slate-600">See confirmations and pending work in one place.</p>
                 <Link
@@ -74,9 +495,13 @@ const Home = () => {
                 </Link>
               </div>
               <div className="rounded-2xl border border-slate-100 bg-slate-50/60 p-4">
-                <p className="text-xs font-semibold uppercase tracking-wider text-[#316fb7]">Need a hand?</p>
+                <p className="text-xs font-semibold uppercase tracking-wider text-[#316fb7]">
+                  Need a hand?
+                </p>
                 <p className="mt-2 font-medium text-slate-900">Team contacts</p>
-                <p className="mt-1 text-slate-600">Reach the platform lead directly from the admin panel.</p>
+                <p className="mt-1 text-slate-600">
+                  Reach the platform lead directly from the admin panel.
+                </p>
                 <Link
                   href="/admin"
                   className="mt-3 inline-flex items-center justify-start text-sm font-semibold text-[#316fb7] hover:text-[#254d85]"
@@ -84,6 +509,53 @@ const Home = () => {
                   Manage users →
                 </Link>
               </div>
+            </div>
+          </div>
+
+          <div className="rounded-3xl bg-white/80 p-8 shadow-lg backdrop-blur">
+            <h3 className="text-xl font-semibold text-slate-900">Today&apos;s maintenance status</h3>
+            <p className="mt-2 text-sm text-slate-600">
+              Review outstanding confirmations before diving into a specific platform.
+            </p>
+            <div className="mt-6 flex flex-wrap items-center gap-6">
+              {isLoadingStats ? (
+                <>
+                  <div className="h-20 w-20 animate-pulse rounded-full bg-slate-100" />
+                  <div className="flex-1 space-y-3">
+                    <div className="h-4 w-48 rounded-full bg-slate-100" />
+                    <div className="h-3 w-60 rounded-full bg-slate-100" />
+                  </div>
+                </>
+              ) : (
+                <>
+                  <ProgressRing
+                    confirmed={aggregatedStats.confirmed}
+                    total={aggregatedStats.total}
+                    label={`Overall: ${aggregatedStats.confirmed} of ${
+                      aggregatedStats.total || 0
+                    } confirmed (${aggregatedPercentage}%)`}
+                    size={96}
+                  />
+                  <div>
+                    <p className="text-base font-semibold text-slate-900">
+                      {aggregatedStats.confirmed}/{aggregatedStats.total || 0} tasks confirmed
+                    </p>
+                    <p className="mt-1 text-sm text-slate-600">{aggregatedMessage}</p>
+                  </div>
+                </>
+              )}
+            </div>
+
+            <div className="mt-6 grid gap-4 md:grid-cols-2">
+              {SERVICES.map((service) => (
+                <PlatformSummaryCard
+                  key={service.key}
+                  service={service}
+                  stats={maintenanceStats[service.key] ?? createEmptyStats()}
+                  error={maintenanceErrors[service.key]}
+                  isLoading={isLoadingStats}
+                />
+              ))}
             </div>
           </div>
         </div>
@@ -114,31 +586,63 @@ const Home = () => {
       </section>
 
       <section className="grid gap-6 md:grid-cols-2">
-        {SERVICES.map((service) => (
-          <Link key={service.name} href={service.href} className="group">
-            <article className={`relative h-full overflow-hidden rounded-3xl border border-white/60 bg-gradient-to-br ${service.gradient} p-8 shadow-lg transition-transform duration-300 group-hover:-translate-y-1 group-hover:shadow-xl`}>
-              <div className="flex items-center gap-4">
-                <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-white/80 shadow">
-                  <Image
-                    src={service.image.src}
-                    alt={service.image.alt}
-                    width={40}
-                    height={40}
-                    className="object-contain"
-                  />
+        {SERVICES.map((service) => {
+          const status = getServiceStatus(service.key);
+          const stats = status.stats ?? maintenanceStats[service.key] ?? createEmptyStats();
+          const dotColor = statusToneToDot[status.type] || "bg-slate-300";
+
+          return (
+            <Link key={service.name} href={service.href} className="group">
+              <article
+                className={`relative h-full overflow-hidden rounded-3xl border border-white/60 bg-gradient-to-br ${service.gradient} p-8 shadow-lg transition-transform duration-300 group-hover:-translate-y-1 group-hover:shadow-xl`}
+              >
+                <div className="flex items-center gap-4">
+                  <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-white/80 shadow">
+                    <Image
+                      src={service.image.src}
+                      alt={service.image.alt}
+                      width={40}
+                      height={40}
+                      className="object-contain"
+                    />
+                  </div>
+                  <div>
+                    <h3 className="text-2xl font-semibold text-slate-900">{service.name}</h3>
+                    <p className="mt-1 text-sm font-medium text-[#316fb7]">{service.badge}</p>
+                  </div>
                 </div>
-                <div>
-                  <h3 className="text-2xl font-semibold text-slate-900">{service.name}</h3>
-                  <p className="mt-1 text-sm font-medium text-[#316fb7]">{service.badge}</p>
+                <p className="mt-5 text-base leading-relaxed text-slate-600">
+                  {service.description}
+                </p>
+
+                <div className="mt-6">
+                  {status.type === "loading" ? (
+                    <div className="h-6 w-36 animate-pulse rounded-full bg-white/60" />
+                  ) : (
+                    <div className="inline-flex flex-col gap-1 rounded-2xl bg-white/70 p-3 text-xs text-slate-700 shadow-sm backdrop-blur">
+                      <div className="flex items-center gap-2 text-sm font-semibold text-slate-900">
+                        <span className={`h-2 w-2 rounded-full ${dotColor}`} />
+                        {status.headline}
+                      </div>
+                      {status.description && (
+                        <p className="text-xs text-slate-600">{status.description}</p>
+                      )}
+                      {status.type !== "error" && (
+                        <p className="text-xs text-slate-500">
+                          {stats.confirmed}/{stats.total || 0} confirmed
+                        </p>
+                      )}
+                    </div>
+                  )}
                 </div>
-              </div>
-              <p className="mt-5 text-base leading-relaxed text-slate-600">{service.description}</p>
-              <span className="mt-6 inline-flex items-center text-sm font-semibold text-[#316fb7] transition-colors group-hover:text-[#254d85]">
-                Open workspace →
-              </span>
-            </article>
-          </Link>
-        ))}
+
+                <span className="mt-6 inline-flex items-center text-sm font-semibold text-[#316fb7] transition-colors group-hover:text-[#254d85]">
+                  Open workspace →
+                </span>
+              </article>
+            </Link>
+          );
+        })}
       </section>
     </PageContainer>
   );

--- a/frontend/src/app/page.js
+++ b/frontend/src/app/page.js
@@ -2,15 +2,12 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
 
 import PageContainer from "./components/PageContainer";
-import { fetchSupportpalSites, fetchWordpressSites } from "./lib/api";
 import { useAuth } from "./lib/auth-context";
 
 const SERVICES = [
   {
-    key: "wordpress",
     name: "WordPress",
     description:
       "Review plugin updates, confirm content deployments, and track maintenance history for each site.",
@@ -23,7 +20,6 @@ const SERVICES = [
     gradient: "from-[#f0f6ff] to-white",
   },
   {
-    key: "supportpal",
     name: "SupportPal",
     description:
       "Monitor ticketing infrastructure, confirm server updates, and document follow-up actions.",
@@ -37,424 +33,14 @@ const SERVICES = [
   },
 ];
 
-const createEmptyStats = () => ({
-  total: 0,
-  confirmed: 0,
-  pending: 0,
-  pendingNames: [],
-  confirmedNames: [],
-});
-
-const createInitialStats = () => ({
-  wordpress: createEmptyStats(),
-  supportpal: createEmptyStats(),
-});
-
-const truthyStrings = new Set([
-  "true",
-  "1",
-  "t",
-  "y",
-  "yes",
-  "done",
-  "complete",
-  "completed",
-  "confirmed",
-]);
-
-const falsyStrings = new Set(["false", "0", "f", "n", "no", "pending", "incomplete"]);
-
-const normaliseConfirmation = (value) => {
-  if (typeof value === "boolean") {
-    return value;
-  }
-
-  if (typeof value === "number") {
-    return value !== 0;
-  }
-
-  if (typeof value === "string") {
-    const normalised = value.trim().toLowerCase();
-
-    if (truthyStrings.has(normalised)) {
-      return true;
-    }
-
-    if (falsyStrings.has(normalised)) {
-      return false;
-    }
-  }
-
-  return false;
-};
-
-const deriveSiteName = (site, index) => {
-  if (site?.name && typeof site.name === "string" && site.name.trim()) {
-    return site.name.trim();
-  }
-
-  if (site?.url && typeof site.url === "string" && site.url.trim()) {
-    return site.url.trim();
-  }
-
-  return `Entry ${index + 1}`;
-};
-
-const buildMaintenanceStats = (sites = []) => {
-  const stats = createEmptyStats();
-  const list = Array.isArray(sites) ? sites : [];
-
-  stats.total = list.length;
-
-  list.forEach((site, index) => {
-    const rawStatus = site?.isConfirmed ?? site?.is_confirmed;
-    const isConfirmed = normaliseConfirmation(rawStatus);
-    const displayName = deriveSiteName(site, index);
-
-    if (isConfirmed) {
-      stats.confirmed += 1;
-      stats.confirmedNames.push(displayName);
-      return;
-    }
-
-    stats.pending += 1;
-    stats.pendingNames.push(displayName);
-  });
-
-  return stats;
-};
-
-const extractErrorMessage = (error, fallbackMessage) => {
-  if (!error) {
-    return fallbackMessage;
-  }
-
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-
-  if (typeof error === "string" && error.trim()) {
-    return error.trim();
-  }
-
-  return fallbackMessage;
-};
-
-const summariseNames = (names = [], limit = 4) => {
-  if (!Array.isArray(names) || names.length === 0) {
-    return [];
-  }
-
-  const trimmed = names
-    .map((name) => (typeof name === "string" ? name.trim() : ""))
-    .filter(Boolean);
-
-  if (trimmed.length <= limit) {
-    return trimmed;
-  }
-
-  const visible = trimmed.slice(0, limit - 1);
-  const remaining = trimmed.length - visible.length;
-
-  return [...visible, `+${remaining} more`];
-};
-
-const getCompletionPercentage = (confirmed, total) => {
-  if (!total) {
-    return 0;
-  }
-
-  const percentage = Math.round((confirmed / total) * 100);
-  return Math.min(100, Math.max(0, percentage));
-};
-
-const ProgressRing = ({ confirmed, total, label, size = 88 }) => {
-  const percentage = getCompletionPercentage(confirmed, total);
-  const innerOffset = Math.max(6, Math.round(size * 0.2));
-
-  return (
-    <div
-      className="relative flex items-center justify-center"
-      style={{ width: size, height: size }}
-      role="img"
-      aria-label={
-        label || `${confirmed} of ${total || 0} maintenance tasks confirmed (${percentage}%)`
-      }
-    >
-      <div
-        className="absolute inset-0 rounded-full"
-        style={{
-          background: `conic-gradient(#22c55e ${percentage}%, rgba(148, 163, 184, 0.35) ${percentage}% 100%)`,
-        }}
-      />
-      <div
-        className="absolute rounded-full bg-white"
-        style={{ inset: innerOffset }}
-        aria-hidden
-      />
-      <span className="relative text-xs font-semibold text-slate-900">
-        {confirmed}/{total || 0}
-      </span>
-    </div>
-  );
-};
-
-const PlatformSummaryCard = ({ service, stats, error, isLoading }) => {
-  if (isLoading) {
-    return (
-      <div className="rounded-2xl border border-slate-100 bg-white/70 p-4 shadow-sm">
-        <div className="flex items-center gap-4">
-          <div className="h-16 w-16 animate-pulse rounded-full bg-slate-100" />
-          <div className="flex-1 space-y-3">
-            <div className="h-3 w-28 rounded-full bg-slate-100" />
-            <div className="h-3 w-40 rounded-full bg-slate-100" />
-            <div className="h-3 w-24 rounded-full bg-slate-100" />
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="rounded-2xl border border-amber-200 bg-amber-50/80 p-4 text-sm text-amber-700 shadow-sm">
-        <p className="font-semibold">{service.name}</p>
-        <p className="mt-1 leading-relaxed">{error}</p>
-        <p className="mt-2 text-xs text-amber-600">
-          Open the {service.name} workspace to retry loading maintenance status.
-        </p>
-      </div>
-    );
-  }
-
-  const { total, confirmed, pending, pendingNames, confirmedNames } = stats;
-  const pendingDisplay = summariseNames(pendingNames);
-  const confirmedDisplay = summariseNames(confirmedNames);
-  const percentage = getCompletionPercentage(confirmed, total);
-
-  const statusMessage = (() => {
-    if (!total) {
-      return "No maintenance records yet.";
-    }
-
-    if (pending === 0) {
-      return "All maintenance confirmed.";
-    }
-
-    return `${pending} awaiting confirmation.`;
-  })();
-
-  return (
-    <div className="rounded-2xl border border-slate-100 bg-white/70 p-4 shadow-sm">
-      <div className="flex items-start gap-4">
-        <ProgressRing
-          confirmed={confirmed}
-          total={total}
-          label={`${service.name}: ${confirmed} of ${total || 0} confirmed (${percentage}%)`}
-          size={80}
-        />
-        <div className="flex-1">
-          <p className="text-sm font-semibold text-slate-900">{service.name}</p>
-          <p className="mt-1 text-xs text-slate-600">{statusMessage}</p>
-          <p className="mt-2 text-xs text-slate-500">
-            <span className="font-semibold text-emerald-600">{confirmed}</span> confirmed ·{" "}
-            <span className="font-semibold text-amber-600">{pending}</span> pending
-          </p>
-
-          {pendingDisplay.length > 0 && (
-            <div className="mt-3">
-              <p className="text-xs font-semibold uppercase tracking-wide text-amber-600">
-                Waiting for confirmation
-              </p>
-              <ul className="mt-1 flex flex-wrap gap-1">
-                {pendingDisplay.map((name, index) => (
-                  <li
-                    key={`${service.key}-pending-${index}`}
-                    className="rounded-full bg-amber-100 px-2.5 py-1 text-[11px] font-medium text-amber-700"
-                  >
-                    {name}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-
-          {confirmedDisplay.length > 0 && (
-            <div className="mt-3">
-              <p className="text-xs font-semibold uppercase tracking-wide text-emerald-600">
-                Completed confirmations
-              </p>
-              <ul className="mt-1 flex flex-wrap gap-1">
-                {confirmedDisplay.map((name, index) => (
-                  <li
-                    key={`${service.key}-confirmed-${index}`}
-                    className="rounded-full bg-emerald-100 px-2.5 py-1 text-[11px] font-medium text-emerald-700"
-                  >
-                    {name}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-};
-
 const Home = () => {
   const { user } = useAuth();
-
-  const [maintenanceStats, setMaintenanceStats] = useState(() => createInitialStats());
-  const [maintenanceErrors, setMaintenanceErrors] = useState({ wordpress: null, supportpal: null });
-  const [isLoadingStats, setIsLoadingStats] = useState(true);
 
   const greetingName = [user?.firstname, user?.username, user?.email].find(
     (value) => typeof value === "string" && value.trim().length > 0
   );
 
   const safeGreeting = greetingName ? greetingName.trim() : "";
-
-  useEffect(() => {
-    let isMounted = true;
-
-    const loadStats = async () => {
-      setIsLoadingStats(true);
-
-      const [wpResult, spResult] = await Promise.allSettled([
-        fetchWordpressSites(),
-        fetchSupportpalSites(),
-      ]);
-
-      if (!isMounted) {
-        return;
-      }
-
-      const nextStats = createInitialStats();
-      const nextErrors = { wordpress: null, supportpal: null };
-
-      if (wpResult.status === "fulfilled") {
-        nextStats.wordpress = buildMaintenanceStats(wpResult.value);
-      } else {
-        nextErrors.wordpress = extractErrorMessage(
-          wpResult.reason,
-          "Unable to load WordPress maintenance status."
-        );
-      }
-
-      if (spResult.status === "fulfilled") {
-        nextStats.supportpal = buildMaintenanceStats(spResult.value);
-      } else {
-        nextErrors.supportpal = extractErrorMessage(
-          spResult.reason,
-          "Unable to load SupportPal maintenance status."
-        );
-      }
-
-      setMaintenanceStats(nextStats);
-      setMaintenanceErrors(nextErrors);
-      setIsLoadingStats(false);
-    };
-
-    loadStats();
-
-    return () => {
-      isMounted = false;
-    };
-  }, []);
-
-  const aggregatedStats = useMemo(
-    () =>
-      Object.values(maintenanceStats).reduce(
-        (acc, stats) => {
-          acc.total += stats.total;
-          acc.confirmed += stats.confirmed;
-          acc.pending += stats.pending;
-          return acc;
-        },
-        { total: 0, confirmed: 0, pending: 0 }
-      ),
-    [maintenanceStats]
-  );
-
-  const aggregatedPercentage = getCompletionPercentage(
-    aggregatedStats.confirmed,
-    aggregatedStats.total
-  );
-
-  const aggregatedMessage = useMemo(() => {
-    if (isLoadingStats) {
-      return "Loading maintenance progress…";
-    }
-
-    if (!aggregatedStats.total) {
-      return "Add your first maintenance record to begin tracking progress.";
-    }
-
-    if (aggregatedStats.pending === 0) {
-      return "All maintenance across WordPress and SupportPal is confirmed.";
-    }
-
-    const plural = aggregatedStats.pending === 1 ? "" : "s";
-    return `${aggregatedStats.pending} pending confirmation${plural} across all platforms.`;
-  }, [aggregatedStats, isLoadingStats]);
-
-  const getServiceStatus = (serviceKey) => {
-    const stats = maintenanceStats[serviceKey] ?? createEmptyStats();
-
-    if (isLoadingStats) {
-      return {
-        type: "loading",
-        headline: "Loading status…",
-        description: "",
-        stats,
-      };
-    }
-
-    const error = maintenanceErrors[serviceKey];
-    if (error) {
-      return {
-        type: "error",
-        headline: "Status unavailable",
-        description: error,
-        stats,
-      };
-    }
-
-    if (!stats.total) {
-      return {
-        type: "info",
-        headline: "No maintenance records yet.",
-        description: "Start by adding a site to begin tracking progress.",
-        stats,
-      };
-    }
-
-    if (stats.pending === 0) {
-      return {
-        type: "success",
-        headline: "All maintenance confirmed.",
-        description: "Everything is up to date for this cycle.",
-        stats,
-      };
-    }
-
-    const plural = stats.pending === 1 ? "" : "s";
-    return {
-      type: "warning",
-      headline: `${stats.pending} pending confirmation${plural}.`,
-      description: "Review outstanding records before you proceed.",
-      stats,
-    };
-  };
-
-  const statusToneToDot = {
-    loading: "bg-slate-300",
-    error: "bg-amber-600",
-    info: "bg-slate-400",
-    success: "bg-emerald-500",
-    warning: "bg-amber-500",
-  };
 
   return (
     <PageContainer
@@ -511,53 +97,6 @@ const Home = () => {
               </div>
             </div>
           </div>
-
-          <div className="rounded-3xl bg-white/80 p-8 shadow-lg backdrop-blur">
-            <h3 className="text-xl font-semibold text-slate-900">Today&apos;s maintenance status</h3>
-            <p className="mt-2 text-sm text-slate-600">
-              Review outstanding confirmations before diving into a specific platform.
-            </p>
-            <div className="mt-6 flex flex-wrap items-center gap-6">
-              {isLoadingStats ? (
-                <>
-                  <div className="h-20 w-20 animate-pulse rounded-full bg-slate-100" />
-                  <div className="flex-1 space-y-3">
-                    <div className="h-4 w-48 rounded-full bg-slate-100" />
-                    <div className="h-3 w-60 rounded-full bg-slate-100" />
-                  </div>
-                </>
-              ) : (
-                <>
-                  <ProgressRing
-                    confirmed={aggregatedStats.confirmed}
-                    total={aggregatedStats.total}
-                    label={`Overall: ${aggregatedStats.confirmed} of ${
-                      aggregatedStats.total || 0
-                    } confirmed (${aggregatedPercentage}%)`}
-                    size={96}
-                  />
-                  <div>
-                    <p className="text-base font-semibold text-slate-900">
-                      {aggregatedStats.confirmed}/{aggregatedStats.total || 0} tasks confirmed
-                    </p>
-                    <p className="mt-1 text-sm text-slate-600">{aggregatedMessage}</p>
-                  </div>
-                </>
-              )}
-            </div>
-
-            <div className="mt-6 grid gap-4 md:grid-cols-2">
-              {SERVICES.map((service) => (
-                <PlatformSummaryCard
-                  key={service.key}
-                  service={service}
-                  stats={maintenanceStats[service.key] ?? createEmptyStats()}
-                  error={maintenanceErrors[service.key]}
-                  isLoading={isLoadingStats}
-                />
-              ))}
-            </div>
-          </div>
         </div>
 
         <div className="rounded-3xl border border-white/60 bg-white/80 p-8 shadow-lg backdrop-blur">
@@ -581,68 +120,50 @@ const Home = () => {
                 </p>
               </div>
             </li>
+            <li className="flex items-start gap-3">
+              <span className="mt-0.5 inline-flex h-2.5 w-2.5 flex-shrink-0 rounded-full bg-[#316fb7]" />
+              <div>
+                <p className="font-medium text-slate-900">Shared documentation</p>
+                <p className="mt-1 leading-relaxed text-slate-600">
+                  Reference the maintenance log to understand who confirmed what and when.
+                </p>
+              </div>
+            </li>
           </ul>
         </div>
       </section>
 
       <section className="grid gap-6 md:grid-cols-2">
-        {SERVICES.map((service) => {
-          const status = getServiceStatus(service.key);
-          const stats = status.stats ?? maintenanceStats[service.key] ?? createEmptyStats();
-          const dotColor = statusToneToDot[status.type] || "bg-slate-300";
-
-          return (
-            <Link key={service.name} href={service.href} className="group">
-              <article
-                className={`relative h-full overflow-hidden rounded-3xl border border-white/60 bg-gradient-to-br ${service.gradient} p-8 shadow-lg transition-transform duration-300 group-hover:-translate-y-1 group-hover:shadow-xl`}
-              >
-                <div className="flex items-center gap-4">
-                  <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-white/80 shadow">
-                    <Image
-                      src={service.image.src}
-                      alt={service.image.alt}
-                      width={40}
-                      height={40}
-                      className="object-contain"
-                    />
-                  </div>
-                  <div>
-                    <h3 className="text-2xl font-semibold text-slate-900">{service.name}</h3>
-                    <p className="mt-1 text-sm font-medium text-[#316fb7]">{service.badge}</p>
-                  </div>
+        {SERVICES.map((service) => (
+          <Link key={service.name} href={service.href} className="group">
+            <article
+              className={`relative h-full overflow-hidden rounded-3xl border border-white/60 bg-gradient-to-br ${service.gradient} p-8 shadow-lg transition-transform duration-300 group-hover:-translate-y-1 group-hover:shadow-xl`}
+            >
+              <div className="flex items-center gap-4">
+                <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-white/80 shadow">
+                  <Image
+                    src={service.image.src}
+                    alt={service.image.alt}
+                    width={40}
+                    height={40}
+                    className="object-contain"
+                  />
                 </div>
-                <p className="mt-5 text-base leading-relaxed text-slate-600">
-                  {service.description}
-                </p>
-
-                <div className="mt-6">
-                  {status.type === "loading" ? (
-                    <div className="h-6 w-36 animate-pulse rounded-full bg-white/60" />
-                  ) : (
-                    <div className="inline-flex flex-col gap-1 rounded-2xl bg-white/70 p-3 text-xs text-slate-700 shadow-sm backdrop-blur">
-                      <div className="flex items-center gap-2 text-sm font-semibold text-slate-900">
-                        <span className={`h-2 w-2 rounded-full ${dotColor}`} />
-                        {status.headline}
-                      </div>
-                      {status.description && (
-                        <p className="text-xs text-slate-600">{status.description}</p>
-                      )}
-                      {status.type !== "error" && (
-                        <p className="text-xs text-slate-500">
-                          {stats.confirmed}/{stats.total || 0} confirmed
-                        </p>
-                      )}
-                    </div>
-                  )}
+                <div>
+                  <h3 className="text-2xl font-semibold text-slate-900">{service.name}</h3>
+                  <p className="mt-1 text-sm font-medium text-[#316fb7]">{service.badge}</p>
                 </div>
+              </div>
+              <p className="mt-5 text-base leading-relaxed text-slate-600">
+                {service.description}
+              </p>
 
-                <span className="mt-6 inline-flex items-center text-sm font-semibold text-[#316fb7] transition-colors group-hover:text-[#254d85]">
-                  Open workspace →
-                </span>
-              </article>
-            </Link>
-          );
-        })}
+              <span className="mt-6 inline-flex items-center text-sm font-semibold text-[#316fb7] transition-colors group-hover:text-[#254d85]">
+                Open workspace →
+              </span>
+            </article>
+          </Link>
+        ))}
       </section>
     </PageContainer>
   );

--- a/frontend/src/app/page.js
+++ b/frontend/src/app/page.js
@@ -42,7 +42,7 @@ const Home = () => {
   return (
     <PageContainer
       meta="Maintenance workspace"
-      title={`Welcome back${safeGreeting ? `, ${safeGreeting}` : ""}!`}`
+      title={`Welcome back${safeGreeting ? ", " + safeGreeting : ""}!`}
       description="Choose the platform you would like to maintain. Everything shares the same visual language so you can move between systems with confidence."
       actions={(
         <div className="rounded-2xl bg-white/70 px-6 py-4 text-sm text-slate-600 shadow-sm backdrop-blur">

--- a/frontend/src/app/page.js
+++ b/frontend/src/app/page.js
@@ -2,10 +2,9 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
 
 import PageContainer from "./components/PageContainer";
+import { useAuth } from "./lib/auth-context";
 
 const SERVICES = [
   {
@@ -33,38 +32,17 @@ const SERVICES = [
 ];
 
 const Home = () => {
-  const router = useRouter();
-  const [user, setUser] = useState(null);
+  const { user } = useAuth();
 
-  useEffect(() => {
-    const token = localStorage.getItem("accessToken");
-    const storedUser = localStorage.getItem("user");
+  const greetingName = [user?.firstname, user?.username, user?.email]
+    .find((value) => typeof value === "string" && value.trim().length > 0);
 
-    if (!token || !storedUser) {
-      router.push("/login");
-      return;
-    }
-
-    try {
-      setUser(JSON.parse(storedUser));
-    } catch (error) {
-      console.error("Unable to parse stored user", error);
-      router.push("/login");
-    }
-  }, [router]);
-
-  if (!user) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-[#f2f7ff] via-white to-[#e3edff] text-slate-600">
-        Loading your workspace…
-      </div>
-    );
-  }
+  const safeGreeting = greetingName ? greetingName.trim() : "";
 
   return (
     <PageContainer
       meta="Maintenance workspace"
-      title={`Welcome back, ${user.firstname}!`}
+      title={`Welcome back${safeGreeting ? `, ${safeGreeting}` : ""}!`}`
       description="Choose the platform you would like to maintain. Everything shares the same visual language so you can move between systems with confidence."
       actions={(
         <div className="rounded-2xl bg-white/70 px-6 py-4 text-sm text-slate-600 shadow-sm backdrop-blur">


### PR DESCRIPTION
## Summary
- introduce an auth context inside `AuthGuard` to centralise token parsing and share session data
- update the layout, home page, navigation sidebar, and admin console to rely on the shared session instead of bespoke localStorage checks
- improve admin access fallbacks and modal initialisation so the console loads reliably for authorised users

## Testing
- `npm run lint` *(fails: prompts to initialise ESLint configuration, command cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6903241230a0832d823323b0fd8f0897